### PR TITLE
Avoid deprecation warnings when generating plist on install

### DIFF
--- a/faktory.erb
+++ b/faktory.erb
@@ -35,31 +35,10 @@ class Faktory < Formula
     end
   end
 
-
-  plist_options :manual => "faktory"
-
-  def plist; <<~EOT
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>Program</key>
-        <string>#{bin}/faktory</string>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>EnvironmentVariables</key>
-        <dict>
-          <key>PATH</key>
-          <string>#{HOMEBREW_PREFIX}/sbin:/usr/sbin:/usr/bin:/bin:#{HOMEBREW_PREFIX}/bin</string>
-        </dict>
-      </dict>
-    </plist>
-    EOT
+  service do
+    run bin/"faktory"
+    environment_variables PATH: "#{HOMEBREW_PREFIX}/sbin:/usr/sbin:/usr/bin:/bin:#{HOMEBREW_PREFIX}/bin"
   end
-
 
   test do
     shell_output("#{bin}/faktory -v", 0)


### PR DESCRIPTION
Using `plist_options` results in this warning on install:

    Warning: Calling plist_options is deprecated! Use service.require_root instead.


At the bottom I've put more information about the old plist and the new one, but the big differences are:

* A new `LimitLoadToSessionType` that Homebrew [always places in every new plist](https://github.com/Homebrew/brew/blob/336c2c792d478d5514291782467a30ebe91c8e84/Library/Homebrew/service.rb#L415-L421)
* `ProgramArguments` instead of `Program` (though there are no arguments, so this is effectively the same as before)

The other difference is the "Caveats" that print after the formula is installed. It now shows the full path after "just run":

```
==> Caveats
To restart contribsys/faktory/faktory after an upgrade:
  brew services restart contribsys/faktory/faktory
Or, if you don't want/need a background service you can just run:
  /usr/local/opt/faktory/bin/faktory
```

This command was previously set by the argument `plist_manual`. It seems that the only way to override that line is with a custom `caveats` method (like [this](https://github.com/Homebrew/homebrew-core/blob/16912e292916a3a96b7c2e22b965b9601344be56/Formula/vlmcsd.rb#L44-L56)). Let me know and I can add it if you'd like.

## Plists

Old plist:

<details>
```plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>Label</key>
    <string>homebrew.mxcl.faktory</string>
    <key>Program</key>
    <string>/usr/local/opt/faktory/bin/faktory</string>
    <key>RunAtLoad</key>
    <true/>
    <key>EnvironmentVariables</key>
    <dict>
      <key>PATH</key>
      <string>/usr/local/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin</string>
    </dict>
  </dict>
</plist>
```
</details>

New plist:


<details>
```plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>EnvironmentVariables</key>
	<dict>
		<key>PATH</key>
		<string>/usr/local/sbin:/usr/sbin:/usr/bin:/bin:/usr/local/bin</string>
	</dict>
	<key>Label</key>
	<string>homebrew.mxcl.faktory</string>
	<key>LimitLoadToSessionType</key>
	<array>
		<string>Aqua</string>
		<string>Background</string>
		<string>LoginWindow</string>
		<string>StandardIO</string>
		<string>System</string>
	</array>
	<key>ProgramArguments</key>
	<array>
		<string>/usr/local/opt/faktory/bin/faktory</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
</dict>
</plist>
```
</details>